### PR TITLE
Allow running puppeteer in headless mode

### DIFF
--- a/built/brave/puppeteer.js
+++ b/built/brave/puppeteer.js
@@ -49,7 +49,7 @@ export const puppeteerConfigForArgs = (args) => {
             '--disable-sync'
         ],
         dumpio: args.debugLevel !== 'none',
-        headless: false
+        headless: args.headless
     };
     if (args.debugLevel === 'verbose') {
         puppeteerArgs.args.push('--enable-logging=stderr');

--- a/built/brave/validate.js
+++ b/built/brave/validate.js
@@ -52,6 +52,7 @@ export const validate = (rawArgs) => {
         urls,
         seconds: secs,
         withShieldsUp: (rawArgs.shields === 'up'),
+        headless: rawArgs.headless,
         debugLevel: rawArgs.debug,
         existingProfilePath: undefined,
         persistProfilePath: undefined,

--- a/built/run.js
+++ b/built/run.js
@@ -5,6 +5,7 @@ import { validate } from './brave/validate.js';
 const defaultCrawlSecs = 30;
 const defaultShieldsSetting = 'down';
 const defaultDebugSetting = 'none';
+const defaultHeadlessMode = false;
 const parser = new argparseLib.ArgumentParser({
     version: 0.1,
     addHelp: true,
@@ -37,6 +38,11 @@ parser.addArgument(['-s', '--shields'], {
         `"--existing-profile".  Default: ${defaultShieldsSetting}`,
     choices: ['up', 'down'],
     defaultValue: defaultShieldsSetting
+});
+parser.addArgument(['--headless'], {
+    help: `Run pagegraph-crawl in headless mode.  Default: ${defaultHeadlessMode}.`,
+    action: 'storeTrue',
+    defaultValue: defaultHeadlessMode
 });
 parser.addArgument(['-t', '--secs'], {
     help: `The dwell time in seconds. Defaults: ${defaultCrawlSecs} sec.`,

--- a/src/brave/puppeteer.ts
+++ b/src/brave/puppeteer.ts
@@ -49,7 +49,7 @@ export const puppeteerConfigForArgs = (args: CrawlArgs): any => {
       '--disable-sync'
     ],
     dumpio: args.debugLevel !== 'none',
-    headless: false
+    headless: args.headless
   }
 
   if (args.debugLevel === 'verbose') {

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -63,6 +63,7 @@ export const validate = (rawArgs: any): ValidationResult => {
     urls,
     seconds: secs,
     withShieldsUp: (rawArgs.shields === 'up'),
+    headless: rawArgs.headless,
     debugLevel: rawArgs.debug,
     existingProfilePath: undefined,
     persistProfilePath: undefined,

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -15,6 +15,7 @@ interface CrawlArgs {
   outputPath: FilePath,
   urls: Url[],
   withShieldsUp: boolean,
+  headless: boolean,
   debugLevel: DebugLevel,
   seconds: number,
   existingProfilePath?: FilePath,

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ import { validate } from './brave/validate.js'
 const defaultCrawlSecs = 30
 const defaultShieldsSetting = 'down'
 const defaultDebugSetting = 'none'
+const defaultHeadlessMode = false
 
 const parser = new argparseLib.ArgumentParser({
   version: 0.1,
@@ -41,6 +42,11 @@ parser.addArgument(['-s', '--shields'], {
         `"--existing-profile".  Default: ${defaultShieldsSetting}`,
   choices: ['up', 'down'],
   defaultValue: defaultShieldsSetting
+})
+parser.addArgument(['--headless'], {
+  help: `Run pagegraph-crawl in headless mode.  Default: ${defaultHeadlessMode}.`,
+  action: 'storeTrue',
+  defaultValue: defaultHeadlessMode
 })
 parser.addArgument(['-t', '--secs'], {
   help: `The dwell time in seconds. Defaults: ${defaultCrawlSecs} sec.`,


### PR DESCRIPTION
Add `--headless` command line param

I edited the `.ts` files and ran `npm run build` - the built js files edited as part of this PR seem to be checked in to git.