### PR TITLE
Redirection code fix

### DIFF
--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -96,10 +96,9 @@ export const doCrawl = async (args: CrawlArgs): Promise<void> => {
       // First load is not a navigation redirect, so we need to skip it.
       let firstLoad = true
       page.on('request', async (request: any) => {
-        const parentFrame = request.frame().parentFrame()
         // Only capture parent frame navigation requests.
         logger.debug(`Request intercepted: ${request.url()}, first load: ${firstLoad}`)
-        if (request.isNavigationRequest() && parentFrame === null && !firstLoad) {
+        if (!firstLoad && request.isNavigationRequest() && request.frame() !== null && request.frame().parentFrame() === null) {
           logger.debug('Page is redirecting...')
           redirectedUrl = request.url()
           // Stop page load


### PR DESCRIPTION
Puppeteer doc says: `The frame that initiated the request, or null if navigating to error pages.` [[doc](https://pptr.dev/api/puppeteer.httprequest/)]
The problem is that the actual code didn't expect the `null` in the `frame()` call.


Url example: `https://www.dailymail.co.uk/`.
Request that crashes: `OPTIONS` `https://hulkprod.anm.co.uk/api/web-push-notification/v1/organisation/mol/analytics/track/prompt/impression`