### PR TITLE
Fix for redirection loop issue

### DIFF
--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -72,7 +72,7 @@ export const doCrawl = async (args: CrawlArgs): Promise<void> => {
   let randomChildUrl: Url = null
   let redirectedUrl: Url = null
   let redirectChain: Url[] = url && [new URL(url)?.pathname === '/' && !url?.endsWith("/") ? url + '/' : url] || [];
-
+  
   const { puppeteerArgs, pathForProfile, shouldClean } = puppeteerConfigForArgs(args)
 
   const envHandle = setupEnv(args)
@@ -100,7 +100,7 @@ export const doCrawl = async (args: CrawlArgs): Promise<void> => {
         // Only capture parent frame navigation requests.
         logger.debug(`Request intercepted: ${request.url()}, first load: ${firstLoad}`)
         logger.debug(`The redirect chain is : \t ${redirectChain}`)
-        if (!firstLoad && request.isNavigationRequest() && request.frame() !== null && request.frame().parentFrame() === null && !(redirectChain.includes(request.url()))) {
+        if (!firstLoad && request.isNavigationRequest() && request.frame() !== null && request.frame().parentFrame() === null && args.crawlDuplicates && !(redirectChain.includes(request.url()))) {
           logger.debug('Page is redirecting...')
           redirectedUrl = request.url()
           // Add the redirected URL to the redirection chain

--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -99,11 +99,10 @@ export const doCrawl = async (args: CrawlArgs,redirectChain: Url[] = []): Promis
       page.on('request', async (request: any) => {
         // Only capture parent frame navigation requests.
         logger.debug(`Request intercepted: ${request.url()}, first load: ${firstLoad}`)
-        logger.debug(`The redirect chain is : \t ${redirectChain}`)
         if (!firstLoad && request.isNavigationRequest() && request.frame() !== null && request.frame().parentFrame() === null) {
           logger.debug('Page is redirecting...')
 
-          if (!args.nocrawlDuplicates || !redirectChain.includes(request.url())){
+          if (args.crawlDuplicates || !redirectChain.includes(request.url())){
           redirectedUrl = request.url()
           // Add the redirected URL to the redirection chain
           redirectChain.push(redirectedUrl);

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -97,7 +97,7 @@ export const validate = (rawArgs: any): ValidationResult => {
   const recursiveDepth: number = rawArgs.recursive_depth
   const interactive: boolean = rawArgs.interactive
   const userAgent: string | undefined = rawArgs.user_agent
-
+  const crawlDuplicates: boolean = rawArgs.no_crawl_duplicates
   const validatedArgs: CrawlArgs = {
     executablePath: String(executablePath),
     outputPath,
@@ -109,7 +109,8 @@ export const validate = (rawArgs: any): ValidationResult => {
     existingProfilePath: undefined,
     persistProfilePath: undefined,
     interactive,
-    userAgent
+    userAgent,
+    crawlDuplicates
   }
 
   if (rawArgs.proxy_server) {

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -97,7 +97,7 @@ export const validate = (rawArgs: any): ValidationResult => {
   const recursiveDepth: number = rawArgs.recursive_depth
   const interactive: boolean = rawArgs.interactive
   const userAgent: string | undefined = rawArgs.user_agent
-  const nocrawlDuplicates: boolean = rawArgs.no_crawl_duplicates
+  const crawlDuplicates: boolean = rawArgs.crawl_duplicates
   const validatedArgs: CrawlArgs = {
     executablePath: String(executablePath),
     outputPath,
@@ -110,7 +110,7 @@ export const validate = (rawArgs: any): ValidationResult => {
     persistProfilePath: undefined,
     interactive,
     userAgent,
-    nocrawlDuplicates
+    crawlDuplicates
   }
 
   if (rawArgs.proxy_server) {

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -97,7 +97,7 @@ export const validate = (rawArgs: any): ValidationResult => {
   const recursiveDepth: number = rawArgs.recursive_depth
   const interactive: boolean = rawArgs.interactive
   const userAgent: string | undefined = rawArgs.user_agent
-  const crawlDuplicates: boolean = rawArgs.no_crawl_duplicates
+  const nocrawlDuplicates: boolean = rawArgs.no_crawl_duplicates
   const validatedArgs: CrawlArgs = {
     executablePath: String(executablePath),
     outputPath,
@@ -110,7 +110,7 @@ export const validate = (rawArgs: any): ValidationResult => {
     persistProfilePath: undefined,
     interactive,
     userAgent,
-    crawlDuplicates
+    nocrawlDuplicates
   }
 
   if (rawArgs.proxy_server) {

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -24,7 +24,7 @@ interface CrawlArgs {
   userAgent?: string,
   proxyServer?: URL,
   extraArgs?: string[],
-  crawlDuplicates: boolean
+  nocrawlDuplicates: boolean
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -23,7 +23,8 @@ interface CrawlArgs {
   interactive: boolean,
   userAgent?: string,
   proxyServer?: URL,
-  extraArgs?: string[]
+  extraArgs?: string[],
+  crawlDuplicates: boolean
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -24,7 +24,7 @@ interface CrawlArgs {
   userAgent?: string,
   proxyServer?: URL,
   extraArgs?: string[],
-  nocrawlDuplicates: boolean
+  crawlDuplicates: boolean
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/run.ts
+++ b/src/run.ts
@@ -73,7 +73,11 @@ parser.addArgument(['-x', '--extra-args'], {
   help: 'Pass JSON_ARRAY as extra CLI argument to the browser instance launched',
   metavar: 'JSON_ARRAY'
 })
-
+parser.addArgument(['-nc','--no-crawl-duplicates'], {
+  help: 'Do not crawl URLs that are already present in the redirection chain',
+  action: 'storeTrue',
+  defaultValue: false
+})
 const rawArgs = parser.parseArgs()
 const [isValid, errorOrArgs] = validate(rawArgs)
 if (!isValid) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -73,8 +73,8 @@ parser.addArgument(['-x', '--extra-args'], {
   help: 'Pass JSON_ARRAY as extra CLI argument to the browser instance launched',
   metavar: 'JSON_ARRAY'
 })
-parser.addArgument(['-nc','--no-crawl-duplicates'], {
-  help: 'Do not crawl URLs that are already present in the redirection chain',
+parser.addArgument(['-c','--crawl-duplicates'], {
+  help: 'Enable crawls for redirected URLs that are already present in the redirection chain',
   action: 'storeTrue',
   defaultValue: false
 })

--- a/test/config.js
+++ b/test/config.js
@@ -2,5 +2,5 @@ export const config = {
   debug: false,
   port: 3000,
   baseUrl: 'http://localhost',
-  pagegraph: '/opt/brave.com/brave-nightly/brave-browser-nightly'
+  pagegraph: '/Applications/Brave\\ Browser\\ Nightly.app/Contents/MacOS/Brave\\ Browser\\ Nightly'
 }

--- a/test/config.js
+++ b/test/config.js
@@ -2,5 +2,5 @@ export const config = {
   debug: false,
   port: 3000,
   baseUrl: 'http://localhost',
-  pagegraph: '/Applications/Brave\\ Browser\\ Nightly.app/Contents/MacOS/Brave\\ Browser\\ Nightly'
+  pagegraph: '/opt/brave.com/brave-nightly/brave-browser-nightly'
 }

--- a/test/pages/index.html
+++ b/test/pages/index.html
@@ -29,10 +29,12 @@
 <body>
 	<h1>Directory Tree</h1><p>
 	<a href=".">.</a><br>
-	├── <a href="./simple.html">simple.html</a><br>
-	├── <a href="./redirect-js-same-site.html">redirect-js-same-site.html</a><br>
 	├── <a href="./multiple-redirects-js-same-site.html">multiple-redirects-js-same-site.html</a><br>
-	└── <a href="./redirect-js-cross-site.html">redirect-js-cross-site.html</a><br>
+	├── <a href="./redirect-js-cross-site.html">redirect-js-cross-site.html</a><br>
+	├── <a href="./redirect-js-same-site.html">redirect-js-same-site.html</a><br>
+	├── <a href="./simple.html">simple.html</a><br>
+	├── <a href="./redirect-chain-A.html">redirect-chain-A.html</a><br>
+	└── <a href="./redirect-chain-B.html">redirect-chain-B.html</a><br>
 	<br><br>
 	</p>
 	<p>

--- a/test/pages/redirect-chain-A.html
+++ b/test/pages/redirect-chain-A.html
@@ -1,0 +1,7 @@
+<html>
+    <!-- Random token for testing -->
+    Jro8qF9KOg
+    <script>
+        window.location.replace("http://127.0.0.1:3000/redirect-chain-B.html");
+    </script>
+</html>

--- a/test/pages/redirect-chain-B.html
+++ b/test/pages/redirect-chain-B.html
@@ -1,0 +1,7 @@
+<html>
+    <!-- Random token for testing -->
+    Ec9Z5dlgA5
+    <script>
+        window.location.replace("http://localhost:3000/redirect-chain-A.html");
+    </script>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -59,7 +59,7 @@ describe('PageGraph Crawl CLI', () => {
 
   const doCrawl = (url) => {
     const crawlPromise = execPromise(
-      `npm run crawl -- -b ${pagegraphBinaryPath} -u ${url} -t 5 -o ${outputDir} ${debugArg} -nc`
+      `npm run crawl -- -b ${pagegraphBinaryPath} -u ${url} -t 5 -o ${outputDir} ${debugArg}`
     )
     DEBUG && crawlPromise.child.stdout.on('data', function (data) {
       console.log(data)


### PR DESCRIPTION
Fixes https://github.com/brave/pagegraph-crawl/issues/33

Whenever a crawl is blocked by Cloudflare, a challenge is shown to the user, which, after a significant time of inactivity, results in a redirection back to the website itself. The current code starts a new crawl on the redirected URL. Due to the infinite number of redirections, the crawl process is never completed.

Here is a snippet of the log related to https://www.terabyteshop.com.br:

```
[1122/034509.523030:VERBOSE1:page_graph.cc(1704)] RegisterStorageRead) key: "https://www.terabyteshop.com.br/", value: "", location: cookie
[1122/034509.524895:VERBOSE2:page_graph.cc(1871)] RegisterJSBuiltInCall) built in: DateConstructor, arguments: {}
[1122/034509.524955:VERBOSE2:page_graph.cc(1892)] RegisterJSBuiltInResponse) built in: DateConstructor, result: "[object Date]"
[1122/034509.525267:VERBOSE2:page_graph.cc(1871)] RegisterJSBuiltInCall) built in: DatePrototypeSetTime, arguments: {"1700628309524"}
[1122/034509.525364:VERBOSE2:page_graph.cc(1892)] RegisterJSBuiltInResponse) built in: DatePrototypeSetTime, result: "1700628309524"
[1122/034509.525467:VERBOSE2:page_graph.cc(1871)] RegisterJSBuiltInCall) built in: DatePrototypeToUTCString, arguments: {}
[1122/034509.525516:VERBOSE2:page_graph.cc(1892)] RegisterJSBuiltInResponse) built in: DatePrototypeToUTCString, result: "Wed, 22 Nov 2023 04:45:09 GMT"
[1122/034509.525971:VERBOSE1:page_graph.cc(1734)] RegisterStorageWrite) key: "cf_chl_rc_ni", value: "1;expires=Wed, 22 Nov 2023 04:45:09 GMT;path=/", location: cookie
[1122/034509.526174:VERBOSE2:page_graph.cc(1822)] RegisterWebAPICall) method: "Window.setTimeout", arguments: {<null>, "2000", "{}"}
[1122/034509.526220:VERBOSE2:page_graph.cc(1842)] RegisterWebAPIResult) method: "Window.setTimeout", result: "9"
[1122/034509.526410:VERBOSE1:page_graph.cc(1562)] RegisterRequestComplete) request id: 16
[1122/034511.527190:VERBOSE2:page_graph.cc(1822)] RegisterWebAPICall) method: "Location.reload", arguments: {}
Request intercepted: https://www.terabyteshop.com.br/, first load: false
Page is redirecting...
Stopping page load of https://www.terabyteshop.com.br
[1122/034512.456141:VERBOSE2:page_graph.cc(1822)] RegisterWebAPICall) method: "console.log", arguments: {"{\"level\":\"kWarning\",\"location\":{\"column\":0,\"line\":0,\"script_id\":0,\"url\":\"https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv0/0/cf6mh/0x4AAAAAAADnOjc0PNeA8qVm/light/normal\"},\"message\":\"The resource https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/cmg/1/OPKxAtcdbeZ4Jv5rehWPxNKLORdkToZsOo7dftrQ3EQ%3D was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.\",\"source\":\"kJavaScript\"}"}
[1122/034512.456266:VERBOSE1:page_graph.cc(1945)] GetCurrentActingNode) script id: 0
[1122/034512.456544:INFO:CONSOLE(0)] "The resource https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/cmg/1/OPKxAtcdbeZ4Jv5rehWPxNKLORdkToZsOo7dftrQ3EQ%3D was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.", source: https://challenges.cloudflare.com/cdn-cgi/challenge-platform/h/g/turnstile/if/ov2/av0/rcv0/0/cf6mh/0x4AAAAAAADnOjc0PNeA8qVm/light/normal (0)
calling generatePageGraph
generatePageGraph { size: 20510494 }
Closing page
Closing the browser
Tearing down Xvfb
Doing new crawl with redirected URL: https://www.terabyteshop.com.br/
Crawling with profile at /tmp/pagegraph-profile--8108-P6CBZmQUrMas.
Running on linux, starting Xvfb
Launching puppeteer with args:  {
  defaultViewport: null,
  args: [
    '--disable-brave-update',
    '--user-data-dir=/tmp/pagegraph-profile--8108-P6CBZmQUrMas',
    '--disable-site-isolation-trials',
    '--enable-features=PageGraph',
    '--no-sandbox',
    '--enable-logging=stderr',
    '--vmodule=page_graph*=2'
  ],
  executablePath: '/opt/brave.com/brave-nightly/brave-browser-nightly',
  ignoreDefaultArgs: [ '--disable-sync' ],
  dumpio: true,
  headless: true
}
_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root
[1122/034535.142255:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[1122/034535.147536:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory
[1122/034535.147657:ERROR:bus.cc(407)] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory

```