### PR TITLE
fix gitignore path, fix empty binary check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 built/
 node_modules/
-out/
 .DS_Store
 .swp

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -69,7 +69,7 @@ export const validate = (rawArgs: any): ValidationResult => {
 
   let executablePath: FilePath | undefined
 
-  if (rawArgs.binary === null) {
+  if (rawArgs.binary === null || rawArgs.binary === undefined) {
     const possibleBinary = guessBinary()
     if (possibleBinary === false) {
       return [false, 'No binary specified, and could not guess one']


### PR DESCRIPTION
fixes brave/pagegraph-crawl#71

Removes an unused entry in .gitignore, and fixes the "guess the binary path" convenience when using the `npm run crawl --` method