### PR TITLE
Waiting behavior small improvement

### DIFF
--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -127,7 +127,7 @@ export const doCrawl = async (args: CrawlArgs, redirectChain: Url[] = []): Promi
 
       logger.debug(`Navigating to ${url}`)
       try {
-      await page.goto(url, { waitUntil: 'domcontentloaded' })
+        await page.goto(url, { waitUntil: 'domcontentloaded' })
       } catch(e) {
         if (e instanceof TimeoutError || (e.name && e.name === 'TimeoutError')) {
           logger.debug('Navigation timeout exceeded.');

--- a/src/brave/crawl.ts
+++ b/src/brave/crawl.ts
@@ -7,7 +7,7 @@ import pathLib from 'path'
 import Xvbf from 'xvfb'
 
 import { getLogger } from './debug.js'
-import { puppeteerConfigForArgs, launchWithRetry } from './puppeteer.js'
+import { puppeteerConfigForArgs, launchWithRetry, TimeoutError } from './puppeteer.js'
 import { isDir } from './validate.js'
 
 const xvfbPlatforms = new Set(['linux', 'openbsd'])
@@ -126,7 +126,15 @@ export const doCrawl = async (args: CrawlArgs, redirectChain: Url[] = []): Promi
       })
 
       logger.debug(`Navigating to ${url}`)
+      try {
       await page.goto(url, { waitUntil: 'domcontentloaded' })
+      } catch(e) {
+        if (e instanceof TimeoutError || (e.name && e.name === 'TimeoutError')) {
+          logger.debug('Navigation timeout exceeded.');
+        } else {
+            throw e;
+        }
+      }
       logger.debug(`Loaded ${url}`)
       const response = await generatePageGraph(args.seconds, page, client, logger)
       writeGraphML(args, url, response, logger)

--- a/src/brave/puppeteer.ts
+++ b/src/brave/puppeteer.ts
@@ -6,6 +6,9 @@ import puppeteerLib from 'puppeteer-core'
 
 import { getLogger } from './debug.js'
 
+
+export const TimeoutError = puppeteerLib.errors.TimeoutError;
+
 const profilePathForArgs = (args: CrawlArgs): { path: FilePath, shouldClean: boolean } => {
   const logger = getLogger(args)
 


### PR DESCRIPTION
I've seen some pages in which the `domcontentloaded` event is not fired during the 30 secs (default by puppeeter) and the pagegraph is not generated because of that.  
This commit fix that behavior. Similar code used by [tracker-radar-collector project](https://github.com/duckduckgo/tracker-radar-collector/blob/main/crawler.js#L205C36-L205C55).

