### PR TITLE
Enable HAR Recordings

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,5 @@ jobs:
         run: |
           shopt -s inherit_errexit
           set -xeEo pipefail
-
-          sed -i 's,pagegraph:.*,pagegraph: "/opt/brave.com/brave-nightly/brave-browser-nightly",' test/config.js
           npm install
-          npm run test
+          PAGEGRAPH_CRAWL_TEST_BINARY_PATH=/opt/brave.com/brave-nightly/brave-browser-nightly npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .DS_Store
 .swp
 .vscode/
+test/debug_output/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command line tool for crawling web pages with PageGraph.
 
 Install
 ---
-For building the tool, you need to have `tsc` (TypeScript Compiler) package installed.
+Requires a recent version of node (current testing is done on `v23.4.0`).
 
 ```bash
 npm install
@@ -32,11 +32,11 @@ npm run crawl -- \
     --debug debug
 ```
 
-The `-t` specifies how many seconds to crawl the URL provided in `-u` using the PageGraph binary in `-b`. 
+The `-t` specifies how many seconds to crawl the URL provided in `-u` using the PageGraph binary in `-b`.
 
 You can see all supported options:
 ```bash
 npm run crawl -- -h
 ```
 
-**NOTE:** PageGraph currently does not track puppeteer / automation scripts, and so modifying or interacting with the document through [devtools/puppeteer](https://pptr.dev/) while recording a PageGraph file will fail.
+**NOTE:** PageGraph currently does not track puppeteer / automation scripts, and so modifying or interacting with the document through [devtools/puppeteer](https://pptr.dev/) while recording a PageGraph file will likely fail.

--- a/built/brave/files.js
+++ b/built/brave/files.js
@@ -1,6 +1,5 @@
-import { writeFile } from 'node:fs/promises';
+import { writeFile, rm } from 'node:fs/promises';
 import { join, parse } from 'node:path';
-import { remove } from 'fs-extra';
 import { isDir } from './checks.js';
 const createFilename = (url) => {
     const fileSafeUrl = String(url).replace(/[^\w]/g, '_');
@@ -11,6 +10,11 @@ const createGraphMLPath = (args, url) => {
     return (isDir(args.outputPath) === true)
         ? join(args.outputPath, createFilename(url))
         : args.outputPath;
+};
+const createHARPath = (args, url) => {
+    const outputPath = createGraphMLPath(args, url);
+    const pathParts = parse(outputPath);
+    return pathParts.dir + '/' + pathParts.name + '.har';
 };
 export const createScreenshotPath = (args, url) => {
     const outputPath = createGraphMLPath(args, url);
@@ -27,6 +31,19 @@ export const writeGraphML = async (args, url, response, logger) => {
         logger.error('saving Page.generatePageGraph output: ', String(err));
     }
 };
+export const writeHAR = async (args, url, har, logger) => {
+    try {
+        const outputFilename = createHARPath(args, url);
+        await writeFile(outputFilename, JSON.stringify(har, null, 4));
+        logger.info('Writing HAR file to: ', outputFilename);
+    }
+    catch (err) {
+        logger.error('saving HAR file: ', String(err));
+    }
+};
 export const deleteAtPath = async (path) => {
-    await remove(path);
+    await rm(path, {
+        recursive: true,
+        force: true,
+    });
 };

--- a/built/brave/puppeteer.js
+++ b/built/brave/puppeteer.js
@@ -1,5 +1,5 @@
+import { cp } from 'node:fs/promises';
 import * as pathLib from 'path';
-import fsExtraLib from 'fs-extra';
 import tmpLib from 'tmp';
 import puppeteerLib from 'puppeteer-core';
 import { getLogger } from './logging.js';
@@ -47,7 +47,9 @@ const profilePathForArgs = (args) => {
         ? args.persistProfilePath
         : tmpLib.dirSync({ prefix: 'pagegraph-profile-' }).name;
     const shouldClean = args.persistProfilePath === undefined;
-    fsExtraLib.copySync(templateProfile, destProfilePath);
+    cp(templateProfile, destProfilePath, {
+        recursive: true,
+    });
     logger.verbose(`Crawling with profile at ${String(destProfilePath)}.`);
     return { profilePath: destProfilePath, shouldClean };
 };

--- a/built/brave/validate.js
+++ b/built/brave/validate.js
@@ -80,6 +80,8 @@ export const validate = (rawArgs) => {
     const userAgent = rawArgs.user_agent;
     const crawlDuplicates = rawArgs.crawl_duplicates;
     const screenshot = rawArgs.screenshot;
+    const storeHar = rawArgs.store_har;
+    const storeHarBody = rawArgs.store_har_body;
     const validatedArgs = {
         executablePath: String(executablePath),
         outputPath,
@@ -96,6 +98,8 @@ export const validate = (rawArgs) => {
         userAgent,
         crawlDuplicates,
         screenshot,
+        storeHar,
+        storeHarBody,
     };
     if (rawArgs.proxy_server !== undefined) {
         try {

--- a/built/brave/validate.js
+++ b/built/brave/validate.js
@@ -1,7 +1,7 @@
 import * as fsLib from 'fs';
 import * as osLib from 'os';
 import * as pathLib from 'path';
-import * as hasBinLib from 'hasbin';
+import hasBinLib from 'hasbin';
 import { asHTTPUrl, isDir, isExecFile } from './checks.js';
 import { getLoggerForLevel } from './logging.js';
 const possibleBraveBinaryPaths = [

--- a/built/run.js
+++ b/built/run.js
@@ -93,6 +93,18 @@ parser.add_argument('--screenshot', {
     dest: 'screenshot',
     default: false,
 });
+parser.add_argument('--har', {
+    help: 'Generate a HAR file at the end of the crawl.',
+    action: 'store_true',
+    dest: 'store_har',
+    default: false,
+});
+parser.add_argument('--har-body', {
+    help: 'Store the response bodies in the HAR file. Only works in combination with --har.',
+    action: 'store_true',
+    dest: 'store_har_body',
+    default: false,
+});
 // parser.add_argument('--no-stealth', {
 //   help: 'Do not enable the "puppeteer-extra-plugin-stealth" extension.',
 //   default: false,

--- a/changelog.md
+++ b/changelog.md
@@ -1,17 +1,31 @@
-Version 1.1.2
+1.1.3
+---
+
+Add ability to record a HAR of the crawled page
+(PR [#180](https://github.com/brave/pagegraph-crawl/pull/180)).
+
+Removed `fs-extras` dependency.
+
+Specify and enforce a minimum node version, v20.0.0.
+
+Clean up and reworking of test runner, including removing the hardcoded
+config file for the tests.
+
+
+1.1.2
 ---
 
 Update eslint to 8.11.0, which resolves a non-useful warning when linting.
 
-Minor version bumps in other depenencies.
+Minor version bumps in other dependencies.
 
 
-Version 1.1.1
+1.1.1
 ---
 
-Minor version bumps in depenencies.
+Minor version bumps in dependencies.
 
-Version 1.1.0
+1.1.0
 ---
 
 Also pass `--disable-first-run-ui`, to suppress some additional, unneeded and
@@ -20,12 +34,12 @@ for the same reason.
 
 Remove some no longer needed dependencies.
 
-Version 1.0.2
+1.0.2
 ---
 
 Fix issue with some landing pages not loading.
 
-Version 1.0.1
+1.0.1
 ---
 
 Add this `changelog.md` file, and start tagging releases.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,9 @@ export default tseslint.config(
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-unused-vars': ['error', {
         "caughtErrorsIgnorePattern": "ignore"
+      }],
+      'camelcase': ['error', {
+        'properties': 'never'
       }]
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "argparse": "^2.0.0",
+        "chrome-har": "^1.0.1",
         "fs-extra": "^11.0.0",
         "hasbin": "^1.2.3",
         "mocha": "^10.7.3",
@@ -1180,6 +1181,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chrome-har": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-har/-/chrome-har-1.0.1.tgz",
+      "integrity": "sha512-FFZCxUrXnXTbNfDyfS+OZxgOTsCm4KSCr73H4g/eOfmJn34u4ZEgInKf8M58fATPZRcrP3un75xR7rRPKdXsGg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.7",
+        "tough-cookie": "5.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/chromium-bidi": {
@@ -3695,6 +3709,24 @@
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
+    "node_modules/tldts": {
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.68.tgz",
+      "integrity": "sha512-JKF17jROiYkjJPT73hUTEiTp2OBCf+kAlB+1novk8i6Q6dWjHsgEjw9VLiipV4KTJavazXhY1QUXyQFSem2T7w==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.68"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.68",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.68.tgz",
+      "integrity": "sha512-85TdlS/DLW/gVdf2oyyzqp3ocS30WxjaL4la85EArl9cHUR/nizifKAJPziWewSZjDZS71U517/i6ciUeqtB5Q==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
@@ -3724,6 +3756,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "pagegraph-crawl",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "CLI for crawling with PageGraph.",
+  "engines" : {
+    "node" : ">=20.0.0"
+  },
   "scripts": {
     "lint": "npx eslint src/**/*.ts src/*.ts",
     "lint:fix": "npx eslint --fix src/**/*.ts src/*.ts",
@@ -11,7 +14,11 @@
     "test": "npm run build && mocha test/test.js --timeout 60000"
   },
   "type": "module",
-  "author": "Peter Snyder <pes@brave.com>",
+  "author": {
+    "email": "pes@brave.com",
+    "name": "Peter Snyder",
+    "url": "https://www.peteresnyder.com"
+  },
   "contributors": [
     {
       "name": "Shivan Kaul Sahib",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "argparse": "^2.0.0",
+    "chrome-har": "^1.0.1",
     "fs-extra": "^11.0.0",
     "hasbin": "^1.2.3",
     "mocha": "^10.7.3",

--- a/src/brave/files.ts
+++ b/src/brave/files.ts
@@ -17,6 +17,12 @@ const createGraphMLPath = (args: CrawlArgs, url: URL): FilePath => {
     : args.outputPath
 }
 
+const createHARPath = (args: CrawlArgs, url: URL): FilePath => {
+  const outputPath = createGraphMLPath(args, url)
+  const pathParts = parse(outputPath)
+  return pathParts.dir + '/' + pathParts.name + '.har'
+}
+
 export const createScreenshotPath = (args: CrawlArgs, url: URL): FilePath => {
   const outputPath = createGraphMLPath(args, url)
   const pathParts = parse(outputPath)
@@ -33,6 +39,18 @@ export const writeGraphML = async (args: CrawlArgs, url: URL,
   }
   catch (err) {
     logger.error('saving Page.generatePageGraph output: ', String(err))
+  }
+}
+
+export const writeHAR = async (args: CrawlArgs, url: URL, har: any,
+                                logger: Logger): Promise<undefined> => {
+  try {
+    const outputFilename = createHARPath(args, url)
+    await writeFile(outputFilename, JSON.stringify(har, null, 4))
+    logger.info('Writing HAR file to: ', outputFilename)
+  }
+  catch (err) {
+    logger.error('saving HAR file: ', String(err))
   }
 }
 

--- a/src/brave/files.ts
+++ b/src/brave/files.ts
@@ -1,7 +1,5 @@
-import { writeFile } from 'node:fs/promises'
+import { writeFile, rm } from 'node:fs/promises'
 import { join, parse } from 'node:path'
-
-import { remove } from 'fs-extra'
 
 import { isDir } from './checks.js'
 
@@ -43,7 +41,7 @@ export const writeGraphML = async (args: CrawlArgs, url: URL,
 }
 
 export const writeHAR = async (args: CrawlArgs, url: URL, har: any,
-                                logger: Logger): Promise<undefined> => {
+                               logger: Logger): Promise<undefined> => {
   try {
     const outputFilename = createHARPath(args, url)
     await writeFile(outputFilename, JSON.stringify(har, null, 4))
@@ -55,5 +53,8 @@ export const writeHAR = async (args: CrawlArgs, url: URL, har: any,
 }
 
 export const deleteAtPath = async (path: FilePath): Promise<undefined> => {
-  await remove(path)
+  await rm(path, {
+    recursive: true,
+    force: true,
+  })
 }

--- a/src/brave/puppeteer.ts
+++ b/src/brave/puppeteer.ts
@@ -1,6 +1,6 @@
+import { cp } from 'node:fs/promises'
 import * as pathLib from 'path'
 
-import fsExtraLib from 'fs-extra'
 import tmpLib from 'tmp'
 import puppeteerLib from 'puppeteer-core'
 // import { PuppeteerExtra, VanillaPuppeteer } from 'puppeteer-extra'
@@ -69,7 +69,9 @@ const profilePathForArgs = (args: CrawlArgs): ProfilePath => {
 
   const shouldClean = args.persistProfilePath === undefined
 
-  fsExtraLib.copySync(templateProfile, destProfilePath)
+  cp(templateProfile, destProfilePath, {
+    recursive: true,
+  })
   logger.verbose(`Crawling with profile at ${String(destProfilePath)}.`)
   return { profilePath: destProfilePath, shouldClean }
 }

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -90,6 +90,8 @@ export const validate = (rawArgs: any): ValidationResult => {  // eslint-disable
   const userAgent: string | undefined = rawArgs.user_agent
   const crawlDuplicates: boolean = rawArgs.crawl_duplicates
   const screenshot: boolean = rawArgs.screenshot
+  const store_har: boolean = rawArgs.store_har
+  const store_har_body: boolean = rawArgs.store_har_body
   const validatedArgs: CrawlArgs = {
     executablePath: String(executablePath),
     outputPath,
@@ -106,6 +108,8 @@ export const validate = (rawArgs: any): ValidationResult => {  // eslint-disable
     userAgent,
     crawlDuplicates,
     screenshot,
+    store_har,
+    store_har_body
   }
 
   if (rawArgs.proxy_server !== undefined) {

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -90,8 +90,8 @@ export const validate = (rawArgs: any): ValidationResult => {  // eslint-disable
   const userAgent: string | undefined = rawArgs.user_agent
   const crawlDuplicates: boolean = rawArgs.crawl_duplicates
   const screenshot: boolean = rawArgs.screenshot
-  const store_har: boolean = rawArgs.store_har
-  const store_har_body: boolean = rawArgs.store_har_body
+  const storeHar: boolean = rawArgs.store_har
+  const storeHarBody: boolean = rawArgs.store_har_body
   const validatedArgs: CrawlArgs = {
     executablePath: String(executablePath),
     outputPath,
@@ -108,8 +108,8 @@ export const validate = (rawArgs: any): ValidationResult => {  // eslint-disable
     userAgent,
     crawlDuplicates,
     screenshot,
-    store_har,
-    store_har_body
+    storeHar,
+    storeHarBody,
   }
 
   if (rawArgs.proxy_server !== undefined) {

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -2,7 +2,7 @@ import * as fsLib from 'fs'
 import * as osLib from 'os'
 import * as pathLib from 'path'
 
-import * as hasBinLib from 'hasbin'
+import hasBinLib from 'hasbin'
 
 import { asHTTPUrl, isDir, isExecFile } from './checks.js'
 import { getLoggerForLevel } from './logging.js'

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -26,8 +26,8 @@ interface CrawlArgs {
   crawlDuplicates: boolean
   screenshot: boolean
   stealth: boolean
-  store_har: boolean
-  store_har_body: boolean
+  storeHar: boolean
+  storeHarBody: boolean
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -2,6 +2,7 @@ declare module 'argparse'
 declare module 'puppeteer-core'
 declare module 'tmp'
 declare module 'xvfb'
+declare module 'chrome-har'
 
 type FilePath = string
 type ErrorMsg = string
@@ -25,6 +26,8 @@ interface CrawlArgs {
   crawlDuplicates: boolean
   screenshot: boolean
   stealth: boolean
+  store_har: boolean
+  store_har_body: boolean
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/run.ts
+++ b/src/run.ts
@@ -97,6 +97,18 @@ parser.add_argument('--screenshot', {
   dest: 'screenshot',
   default: false,
 })
+parser.add_argument('--har', {
+  help: 'Generate a HAR file at the end of the crawl.',
+  action: 'store_true',
+  dest: 'store_har',
+  default: false,
+})
+parser.add_argument('--har-body', {
+  help: 'Store the response bodies in the HAR file. Only works in combination with --har.',
+  action: 'store_true',
+  dest: 'store_har_body',
+  default: false,
+})
 // parser.add_argument('--no-stealth', {
 //   help: 'Do not enable the "puppeteer-extra-plugin-stealth" extension.',
 //   default: false,

--- a/test/config.js
+++ b/test/config.js
@@ -1,6 +1,0 @@
-export const config = {
-  debug: false,
-  port: 3000,
-  baseUrl: 'http://localhost',
-  pagegraph: '/Applications/Brave\\ Browser\\ Nightly.app/Contents/MacOS/Brave\\ Browser\\ Nightly'
-}


### PR DESCRIPTION
Add the functionality to record HAR files (mentioned in #68) without (`--har`) and with response bodies (plus `--har-body`).

This commit adds the [chrome-har](https://github.com/sitespeedio/chrome-har) dependency (MIT license).

Also, I'm not a big TS developer so it might be that typing could be better. Happy for feedback.

Cheers, Florian