### PR TITLE
Add gzip option and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "argparse": "2.0.1",
     "chrome-har": "1.0.1",
+    "node-gzip": "^1.1.2",
     "puppeteer-core": "23.11.1",
     "which": "5.0.0",
     "xvfb": "0.4.0"
@@ -39,6 +40,7 @@
     "@eslint/js": "9.17.0",
     "@stylistic/eslint-plugin": "2.12.1",
     "@tsconfig/node20": "20.1.4",
+    "@types/node-gzip": "^1.1.3",
     "@types/argparse": "2.0.17",
     "@types/eslint__js": "8.42.3",
     "@types/which": "3.0.4",

--- a/src/brave/files.ts
+++ b/src/brave/files.ts
@@ -8,33 +8,34 @@ import { isDir } from './checks.js'
 const dateTimeStamp = Math.floor(Date.now() / 1000)
 
 const createFilename = (url: URL): FilePath => {
-  const fileSafeUrl = String(url).replace(/[^\w]/g, '_')  
+  const fileSafeUrl = String(url).replace(/[^\w]/g, '_')
   return ['page_graph_', fileSafeUrl, '_', dateTimeStamp].join('')
 }
 const createOutputPath = (args: CrawlArgs, url: URL): FilePath => {
   if (isDir(args.outputPath) === true) {
     return join(args.outputPath, createFilename(url))
-  } else {
+  }
+  else {
     const pathParts = parse(args.outputPath)
     return pathParts.dir + '/' + pathParts.name
   }
 }
 
 const createGraphMLPath = (args: CrawlArgs, url: URL): FilePath => {
-  let outputPath: string = join(createOutputPath(args, url) + '.graphml' )
+  let outputPath: string = join(createOutputPath(args, url) + '.graphml')
   if (args.compress === true) {
-    outputPath = outputPath + ".gz"
+    outputPath = outputPath + '.gz'
   }
   return outputPath
 }
 
 const createHARPath = (args: CrawlArgs, url: URL): FilePath => {
-  const outputPath = join(createOutputPath(args, url) + '.har' )
+  const outputPath = join(createOutputPath(args, url) + '.har')
   return outputPath
 }
 
 export const createScreenshotPath = (args: CrawlArgs, url: URL): FilePath => {
-  const outputPath = join(createOutputPath(args, url) + '.png' )
+  const outputPath = join(createOutputPath(args, url) + '.png')
   return outputPath
 }
 
@@ -42,12 +43,11 @@ export const writeGraphML = async (args: CrawlArgs, url: URL,
                                    response: FinalPageGraphEvent,
                                    logger: Logger): Promise<undefined> => {
   try {
-    console.log("WHAT ABOUT COMPRESS? " + args.compress)
     const outputFilename = createGraphMLPath(args, url)
     logger.info('Writing PageGraph file to: ', outputFilename)
     const data = args.compress
-    ? await gzip(response.data)
-    : response.data
+      ? await gzip(response.data)
+      : response.data
     await writeFile(outputFilename, data)
   }
   catch (err) {

--- a/src/brave/files.ts
+++ b/src/brave/files.ts
@@ -1,40 +1,54 @@
 import { rm, writeFile, mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, parse } from 'node:path'
+import { gzip } from 'node-gzip'
 
 import { isDir } from './checks.js'
 
+const dateTimeStamp = Math.floor(Date.now() / 1000)
+
 const createFilename = (url: URL): FilePath => {
-  const fileSafeUrl = String(url).replace(/[^\w]/g, '_')
-  const dateTimeStamp = Math.floor(Date.now() / 1000)
-  return ['page_graph_', fileSafeUrl, '_', dateTimeStamp, '.graphml'].join('')
+  const fileSafeUrl = String(url).replace(/[^\w]/g, '_')  
+  return ['page_graph_', fileSafeUrl, '_', dateTimeStamp].join('')
+}
+const createOutputPath = (args: CrawlArgs, url: URL): FilePath => {
+  if (isDir(args.outputPath) === true) {
+    return join(args.outputPath, createFilename(url))
+  } else {
+    const pathParts = parse(args.outputPath)
+    return pathParts.dir + '/' + pathParts.name
+  }
 }
 
 const createGraphMLPath = (args: CrawlArgs, url: URL): FilePath => {
-  return (isDir(args.outputPath) === true)
-    ? join(args.outputPath, createFilename(url))
-    : args.outputPath
+  let outputPath: string = join(createOutputPath(args, url) + '.graphml' )
+  if (args.compress === true) {
+    outputPath = outputPath + ".gz"
+  }
+  return outputPath
 }
 
 const createHARPath = (args: CrawlArgs, url: URL): FilePath => {
-  const outputPath = createGraphMLPath(args, url)
-  const pathParts = parse(outputPath)
-  return pathParts.dir + '/' + pathParts.name + '.har'
+  const outputPath = join(createOutputPath(args, url) + '.har' )
+  return outputPath
 }
 
 export const createScreenshotPath = (args: CrawlArgs, url: URL): FilePath => {
-  const outputPath = createGraphMLPath(args, url)
-  const pathParts = parse(outputPath)
-  return pathParts.dir + '/' + pathParts.name + '.png'
+  const outputPath = join(createOutputPath(args, url) + '.png' )
+  return outputPath
 }
 
 export const writeGraphML = async (args: CrawlArgs, url: URL,
                                    response: FinalPageGraphEvent,
                                    logger: Logger): Promise<undefined> => {
   try {
+    console.log("WHAT ABOUT COMPRESS? " + args.compress)
     const outputFilename = createGraphMLPath(args, url)
     logger.info('Writing PageGraph file to: ', outputFilename)
-    await writeFile(outputFilename, response.data)
+    const data = args.compress
+    ? await gzip(response.data)
+    : response.data
+    await writeFile(outputFilename, data)
   }
   catch (err) {
     logger.error('saving Page.generatePageGraph output: ', String(err))

--- a/src/brave/validate.ts
+++ b/src/brave/validate.ts
@@ -94,6 +94,7 @@ export const validate = (rawArgs: any): ValidationResult => {  // eslint-disable
   const screenshot: boolean = rawArgs.screenshot
   const storeHar: boolean = rawArgs.store_har
   const storeHarBody: boolean = rawArgs.store_har_body
+  const compress: boolean = rawArgs.compress
   const validatedArgs: CrawlArgs = {
     executablePath: String(executablePath),
     outputPath,
@@ -112,6 +113,7 @@ export const validate = (rawArgs: any): ValidationResult => {  // eslint-disable
     screenshot,
     storeHar,
     storeHarBody,
+    compress,
   }
 
   if (rawArgs.proxy_server !== undefined) {

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -27,6 +27,7 @@ interface CrawlArgs {
   stealth: boolean
   storeHar: boolean
   storeHarBody: boolean
+  compress: boolean
 }
 
 type ValidationResult = [boolean, CrawlArgs | ErrorMsg]

--- a/src/run.ts
+++ b/src/run.ts
@@ -109,6 +109,12 @@ parser.add_argument('--har-body', {
   dest: 'store_har_body',
   default: false,
 })
+parser.add_argument('-z', '--compress', {
+  help: 'Compresses the graphml file as gzip.',
+  action: 'store_true',
+  dest: 'compress',
+  default: false,
+})
 // parser.add_argument('--no-stealth', {
 //   help: 'Do not enable the "puppeteer-extra-plugin-stealth" extension.',
 //   default: false,

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,8 @@
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import nodeGzip from 'node-gzip';
+const { ungzip } = nodeGzip;
 
 import kill from 'tree-kill'
 
@@ -58,6 +60,24 @@ describe('PageGraph Crawl CLI', () => {
         assert.ok(file.endsWith(graphMlExtension))
 
         const graphml = await readFile(join(testDir, file), 'UTF-8')
+        assert.ok(graphml.includes('hJc9ZK1sGr'))
+      } finally {
+        await _cleanupTempOutputDir(testDir)
+      }
+    })
+    it('single static page with gzip', async () => {
+      const testDir = await _createTempOutputDir()
+      try {
+        await _crawlUrl(simpleUrl, testDir, { '--compress': null })
+        const files = await _readCrawlResults(testDir)
+        assert.equal(files.length, 1)
+
+        const file = files[0]
+        assert.ok(file.startsWith(expectedFilenameSimple))
+        assert.ok(file.endsWith(graphMlExtension + ".gz"))
+        
+        const graphml_compressed = await readFile(join(testDir, file))
+        const graphml = await ungzip(graphml_compressed)
         assert.ok(graphml.includes('hJc9ZK1sGr'))
       } finally {
         await _cleanupTempOutputDir(testDir)

--- a/test/test.js
+++ b/test/test.js
@@ -3,9 +3,7 @@
 import assert from 'node:assert'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import nodeGzip from 'node-gzip';
-const { ungzip } = nodeGzip;
-
+import nodeGzip from 'node-gzip'
 import kill from 'tree-kill'
 
 import {
@@ -22,6 +20,8 @@ const graphMlExtension = '.graphml'
 const testBaseUrl = `${baseUrl}:${testServerPort}`
 const simpleUrl = `${testBaseUrl}/simple.html`
 const expectedFilenameSimple = getExpectedFilename(simpleUrl)
+
+const { ungzip } = nodeGzip
 
 const _crawlUrl = async (url, outputDir, args) => {
   return await crawlUrl(url, outputDir, args, binaryPath, DEBUG)
@@ -74,10 +74,10 @@ describe('PageGraph Crawl CLI', () => {
 
         const file = files[0]
         assert.ok(file.startsWith(expectedFilenameSimple))
-        assert.ok(file.endsWith(graphMlExtension + ".gz"))
-        
-        const graphml_compressed = await readFile(join(testDir, file))
-        const graphml = await ungzip(graphml_compressed)
+        assert.ok(file.endsWith(graphMlExtension + '.gz'))
+
+        const graphmlCompressed = await readFile(join(testDir, file))
+        const graphml = await ungzip(graphmlCompressed)
         assert.ok(graphml.includes('hJc9ZK1sGr'))
       } finally {
         await _cleanupTempOutputDir(testDir)


### PR DESCRIPTION
@pes10k  The resulting graphml file has a lot of redundant parts and can be compressed to save storage. This merge request adds an option to compress the graphml automatically, refactors the path construction, and adds a test for the gzip option.